### PR TITLE
Améliorations visuelles des pages pour le matériel et les sacs

### DIFF
--- a/app/views/bags/index.html.erb
+++ b/app/views/bags/index.html.erb
@@ -1,29 +1,42 @@
 <% provide(:title, "Sacs") %>
 
-<h1>Bags</h1>
+<h1>Sacs</h1>
 
-<%= link_to "Gérer le matos", hardwares_path %>
+<%= link_to "Gérer le matériel", hardwares_path %>
+<hr>
 
 <% @bags.each do |bag| %>
-  <h3><%= bag.name %></h3>
-  Il y a dedans :
-  <% if bag.hardwares.any? %>
-    <ul>
-      <% bag.hardwares.each do |h| %>
-        <li><%= "#{h.name} (#{h.hardware_type_string})" %></li>
-      <% end %>
-    </ul>
-  <% else %>
-    rien pour l'instant.
-  <% end %>
+  <div class="bag">
+    <h3><%= bag.name %></h3>
+    Il y a dedans :
+    <% if bag.hardwares.any? %>
+      <ul>
+        <% bag.hardwares.each do |h| %>
+          <li><%= link_to "#{h.name} (#{h.hardware_type_string})", h, title: 'Voir' %></li>
+          <ul>
+            <li><%= "#{h.state_string}"  %></li>
+            <% if h.comment? %>
+              <li><%= "Commentaire : #{h.comment}" %></li>
+            <% else %>
+              <li>Pas de commentaire</li>
+            <% end %>
+          </ul>
+        <% end %>
+      </ul>
+    <% else %>
+      rien pour l'instant.
+    <% end %>
 
-  <%= render "shared/show_owners_list", item: bag %>
-  <br/>
+    <%= render "shared/show_owners_list", item: bag %>
+    <br/>
 
-  <%= link_to 'Show', bag %> |
-  <%= link_to 'Edit', edit_bag_path(bag) %> |
-  <%= link_to 'Destroy', bag, method: :delete, data: { confirm: 'Are you sure?' } %>
-  <hr/>
+    <%= link_to raw('<i class="fa fa-eye alert-info"></i> Voir'), bag, title: 'Voir' %>
+    |
+    <%= link_to raw('<i class="fa fa-pencil-square-o"></i> Éditer'), edit_bag_path(bag), title: 'Éditer' %>
+    |
+    <%= link_to raw('<i class="fa fa-trash-o alert-danger"></i> Détruire'), bag, method: :delete, data: { confirm: 'Êtes-vous sûr·e ?' }, title: 'Détruire' %>
+    <hr/>
+  </div>
 <% end %>
 
-<%= link_to 'New Bag', new_bag_path %>
+<%= link_to 'Nouveau sac', new_bag_path %>

--- a/app/views/bags/index.html.erb
+++ b/app/views/bags/index.html.erb
@@ -30,11 +30,11 @@
     <%= render "shared/show_owners_list", item: bag %>
     <br/>
 
-    <%= link_to raw('<i class="fa fa-eye alert-info"></i> Voir'), bag, title: 'Voir' %>
+    <%= link_to fa_icon('eye'), bag, title: 'Voir', class: 'text-info', data: { toggle: 'tooltip' } %>
     |
-    <%= link_to raw('<i class="fa fa-pencil-square-o"></i> Éditer'), edit_bag_path(bag), title: 'Éditer' %>
+    <%= link_to fa_icon('pencil-square-o'), edit_bag_path(bag), title: 'Éditer', class: 'text-primary', data: { toggle: 'tooltip' } %>
     |
-    <%= link_to raw('<i class="fa fa-trash-o alert-danger"></i> Détruire'), bag, method: :delete, data: { confirm: 'Êtes-vous sûr·e ?' }, title: 'Détruire' %>
+    <%= link_to fa_icon('trash-o'), bag, method: :delete, data: { confirm: 'Êtes-vous sûr·e ?' }, title: 'Détruire', class: 'text-danger', data: { toggle: 'tooltip' } %>
     <hr/>
   </div>
 <% end %>

--- a/app/views/bags/show.html.erb
+++ b/app/views/bags/show.html.erb
@@ -12,10 +12,10 @@
       <li><%= link_to "#{h.name} (#{h.hardware_type_string})", h, title: 'Voir' %></li>
       <ul>
         <li><%= "#{h.state_string}"  %></li>
-	<% if h.comment? %>
+        <% if h.comment? %>
           <li><%= "Commentaire : #{h.comment}" %></li>
         <% else %>
-	  <li>Pas de commentaire</li>
+          <li>Pas de commentaire</li>
         <% end %>
       </ul>
     <% end %>

--- a/app/views/bags/show.html.erb
+++ b/app/views/bags/show.html.erb
@@ -3,18 +3,26 @@
 <p id="notice"><%= notice %></p>
 
 <p>
-  <strong>Name:</strong>
+  <strong>Nom :</strong>
   <%= @bag.name %>
 </p>
 <% if @bag.hardwares.any? %>
   <ul>
     <% @bag.hardwares.each do |h| %>
-      <li><%= "#{h.name} (#{h.hardware_type_string})" %></li>
+      <li><%= link_to "#{h.name} (#{h.hardware_type_string})", h, title: 'Voir' %></li>
+      <ul>
+        <li><%= "#{h.state_string}"  %></li>
+	<% if h.comment? %>
+          <li><%= "Commentaire : #{h.comment}" %></li>
+        <% else %>
+	  <li>Pas de commentaire</li>
+        <% end %>
+      </ul>
     <% end %>
   </ul>
 <% end %>
 
 <%= render "shared/show_owners_list", item: @bag %>
 
-<%= link_to 'Edit', edit_bag_path(@bag) %> |
-<%= link_to 'Back', bags_path %>
+<%= link_to 'Éditer', edit_bag_path(@bag) %> |
+<%= link_to 'Retour', bags_path %>

--- a/app/views/hardwares/index.html.erb
+++ b/app/views/hardwares/index.html.erb
@@ -1,10 +1,9 @@
 <% provide(:title, "Matériel") %>
-
-<h1>Hardwares</h1>
+<h1>Matériel</h1>
 
 <%= link_to "Gérer les sacs", bags_path %>
 
-<table>
+<table id="hardware-index-table" class="table table-striped">
   <thead>
     <tr>
       <th>Nom</th>
@@ -13,7 +12,7 @@
       <th>Commentaire</th>
       <th>Chez qui</th>
       <th>Sac</th>
-      <th colspan="3"></th>
+      <th colspan="3">Actions</th>
     </tr>
   </thead>
 
@@ -22,13 +21,13 @@
       <tr>
         <td><%= hardware.name %></td>
         <td><%= hardware.hardware_type_string %></td>
-        <td><%= hardware.state_string %></td>
+        <td><i class="fa fa-circle state-<%= hardware.state %>" aria-hidden="true"></i></td>
         <td><%= hardware.comment %></td>
         <td><%= hardware.real_owner&.name %></td>
         <td><%= hardware.bag&.name %></td>
-        <td><%= link_to 'Show', hardware %></td>
-        <td><%= link_to 'Edit', edit_hardware_path(hardware) %></td>
-        <td><%= link_to 'Destroy', hardware, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+        <td><%= link_to raw('<i class="fa fa-eye alert-info"></i>'), hardware, title: 'Voir' %></td>
+        <td><%= link_to raw('<i class="fa fa-pencil-square-o"></i>'), edit_hardware_path(hardware), title: 'Éditer' %></td>
+	<td><%= link_to raw('<i class="fa fa-trash-o alert-danger"></i>'), hardware, method: :delete, data: { confirm: 'Êtes-vous sûr·e ?' }, title: 'Détruire' %></td>
       </tr>
     <% end %>
   </tbody>
@@ -36,4 +35,4 @@
 
 <br>
 
-<%= link_to 'New Hardware', new_hardware_path %>
+<%= link_to 'Ajouter du nouveau matériel', new_hardware_path %>

--- a/app/views/hardwares/index.html.erb
+++ b/app/views/hardwares/index.html.erb
@@ -21,13 +21,18 @@
       <tr>
         <td><%= hardware.name %></td>
         <td><%= hardware.hardware_type_string %></td>
-	<td><i class="fa fa-circle state-<%= hardware.state %>" aria-hidden="true" title="<%= hardware.state_string %>"></i><div class="hide"><%= hardware.state_string %></div></td>
+	<td class="state-<%= hardware.state %>">
+          <div title="<%= hardware.state_string %>" data-toggle="tooltip">
+            <%= fa_icon('circle') %>
+            <span class="d-none"><%= hardware.state_string %></span>
+          </div>
+        </td>
         <td><%= hardware.comment %></td>
         <td><%= hardware.real_owner&.name %></td>
         <td><%= hardware.bag&.name %></td>
-        <td><%= link_to raw('<i class="fa fa-eye alert-info"></i>'), hardware, title: 'Voir' %></td>
-        <td><%= link_to raw('<i class="fa fa-pencil-square-o"></i>'), edit_hardware_path(hardware), title: 'Éditer' %></td>
-	<td><%= link_to raw('<i class="fa fa-trash-o alert-danger"></i>'), hardware, method: :delete, data: { confirm: 'Êtes-vous sûr·e ?' }, title: 'Détruire' %></td>
+        <td><%= link_to fa_icon('eye'), hardware, title: 'Voir', class: 'text-info', data: { toggle: 'tooltip' } %></td>
+        <td><%= link_to fa_icon('pencil-square-o'), edit_hardware_path(hardware), title: 'Éditer', class: 'text-primary', data: { toggle: 'tooltip' } %></td>
+        <td><%= link_to fa_icon('trash-o'), hardware, method: :delete, data: { confirm: 'Êtes-vous sûr·e ?' }, title: 'Détruire', class: 'text-danger', data: { toggle: 'tooltip' } %></td>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/hardwares/index.html.erb
+++ b/app/views/hardwares/index.html.erb
@@ -21,7 +21,7 @@
       <tr>
         <td><%= hardware.name %></td>
         <td><%= hardware.hardware_type_string %></td>
-        <td><i class="fa fa-circle state-<%= hardware.state %>" aria-hidden="true"></i></td>
+	<td><i class="fa fa-circle state-<%= hardware.state %>" aria-hidden="true" title="<%= hardware.state_string %>"></i><div class="hide"><%= hardware.state_string %></div></td>
         <td><%= hardware.comment %></td>
         <td><%= hardware.real_owner&.name %></td>
         <td><%= hardware.bag&.name %></td>

--- a/app/views/hardwares/show.html.erb
+++ b/app/views/hardwares/show.html.erb
@@ -23,5 +23,5 @@
   <% end %>
 <% end %>
 
-<%= link_to 'Edit', edit_hardware_path(@hardware) %> |
-<%= link_to 'Back', hardwares_path %>
+<%= link_to 'Éditer', edit_hardware_path(@hardware) %> |
+<%= link_to 'Retour', hardwares_path %>

--- a/app/webpacker/hardwares/index.js
+++ b/app/webpacker/hardwares/index.js
@@ -1,11 +1,1 @@
-$(document).ready(function() 
-  {
-     $("#hardware-index-table").tablesorter(
-       {
-         headers: {
-           6: { sorter: false }
-         }
-       }
-     ); 
-  } 
-);
+$(() => $("#hardware-index-table").tablesorter({ headers: { 6: { sorter: false } } }));

--- a/app/webpacker/hardwares/index.js
+++ b/app/webpacker/hardwares/index.js
@@ -1,0 +1,11 @@
+$(document).ready(function() 
+  {
+     $("#hardware-index-table").tablesorter(
+       {
+         headers: {
+           6: { sorter: false }
+         }
+       }
+     ); 
+  } 
+);

--- a/app/webpacker/packs/application.js
+++ b/app/webpacker/packs/application.js
@@ -12,6 +12,8 @@ import Turbolinks from 'turbolinks';
 
 import 'afs';
 import 'jquery-ujs';
+import 'tablesorter';
+import 'hardwares';
 
 Turbolinks.start();
 

--- a/app/webpacker/packs/hardwares.js
+++ b/app/webpacker/packs/hardwares.js
@@ -1,0 +1,1 @@
+import 'hardwares';

--- a/app/webpacker/packs/stylesheets.scss
+++ b/app/webpacker/packs/stylesheets.scss
@@ -29,6 +29,7 @@
 @import '../src/homepage';
 @import '../src/footer';
 @import '../src/sessions';
+@import '../src/hardwares';
 
 html {
   min-height: 100%;

--- a/app/webpacker/src/hardwares.scss
+++ b/app/webpacker/src/hardwares.scss
@@ -1,11 +1,11 @@
 #hardware-index-table {
   text-align: center;
 
-  .state-ok {
+  .state-ok i {
     color: green;
   }
 
-  .state-ko {
+  .state-ko i {
     color: red;
   }
 
@@ -14,10 +14,6 @@
   }
   .sorter-false:hover {
     cursor: default;
-  }
-
-  .hide {
-    display: none;
   }
 }
 

--- a/app/webpacker/src/hardwares.scss
+++ b/app/webpacker/src/hardwares.scss
@@ -8,6 +8,17 @@
   .state-ko {
     color: red;
   }
+
+  th:hover {
+    cursor: pointer;
+  }
+  .sorter-false:hover {
+    cursor: default;
+  }
+
+  .hide {
+    display: none;
+  }
 }
 
 

--- a/app/webpacker/src/hardwares.scss
+++ b/app/webpacker/src/hardwares.scss
@@ -1,0 +1,13 @@
+#hardware-index-table {
+  text-align: center;
+
+  .state-ok {
+    color: green;
+  }
+
+  .state-ko {
+    color: red;
+  }
+}
+
+

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "resolve-url-loader": "^2.3.0",
     "selectize": "^0.12.4",
     "simplemde": "^1.11.2",
+    "tablesorter": "^2.30.6",
     "turbolinks": "^5.1.1",
     "upath": "1.1.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3237,7 +3237,7 @@ jquery-ujs@^1.2.2:
   dependencies:
     jquery ">=1.8.0"
 
-"jquery@2 - 3", "jquery@>=1.7.1 <4.0.0", jquery@>=1.8.0, jquery@^3.3.1:
+"jquery@2 - 3", jquery@>=1.2.6, "jquery@>=1.7.1 <4.0.0", jquery@>=1.8.0, jquery@^3.3.1:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.3.1.tgz#958ce29e81c9790f31be7792df5d4d95fc57fbca"
 
@@ -5926,6 +5926,12 @@ svgo@^0.7.0:
     mkdirp "~0.5.1"
     sax "~1.2.1"
     whet.extend "~0.9.9"
+
+tablesorter@^2.30.6:
+  version "2.30.6"
+  resolved "https://registry.yarnpkg.com/tablesorter/-/tablesorter-2.30.6.tgz#d24b0a5a9e44f9970d41f51a7d194d538fc6f953"
+  dependencies:
+    jquery ">=1.2.6"
 
 tapable@^0.2.7:
   version "0.2.8"


### PR DESCRIPTION
Traduction en français de la plupart des choses

Page d'accueil hardwares :
- remplacement "fonctionne" / "cassé" par des couleurs
- mise en page dans une table
- ajout tri alphabétique sur n'importe quelle colonne (sauf "actions") (grâce à tablesorter)
- remplacement du texte par des logos font-awesome pour les actions

Pages concernant les sacs : 
- affichage de plus d'infos et de liens qu'avant
- quelques améliorations visuelles

Closes #22 