### PR TITLE
Add data-text to dates for tablesorter

### DIFF
--- a/app/views/subscriptions/index.html.erb
+++ b/app/views/subscriptions/index.html.erb
@@ -21,7 +21,7 @@
         <td>
           <%= link_to_wca_profile(s.wca_id) %>
         </td>
-        <td><%= l(s.until) %></td>
+        <td data-text="<%= s.until %>"><%= l(s.until) %></td>
       </tr>
     <% end %>
   <% end %>


### PR DESCRIPTION
tablesorter utilise [`textextraction`](https://mottie.github.io/tablesorter/docs/#textextraction) pour récupérer les données sur lesquelles il effectue le tri. Et en particulier il récupère l'attribut [`data-text`](https://mottie.github.io/tablesorter/docs/#textattribute) s'il existe, du coup il suffit de mettre la date au format par défaut (`YYYY-MM-DD`) dedans pour avoir un tri qui fonctionne.