### PR TITLE
Import des adhésions avec find_by + new au lieu de find_or_initialize_by

### DIFF
--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -46,13 +46,13 @@ class SubscriptionsController < ApplicationController
       CSV.foreach(csvfile.path, :headers => true, :col_sep => ';') do |row|
         # Row may not follow a specific format, however we should have the following headers:
         # Nom;Prénom;Date;Email;Attestation;Champ additionnel: ID WCA (si connu)
-        subscription = Subscription.find_or_initialize_by(name: row["Nom"].strip,
-                                                          firstname: row["Prénom"].strip,
-                                                          payed_at: DateTime.parse(row["Date"]),
-                                                          email: row["Email"]&.strip,
+        subscription = Subscription.find_or_initialize_by(payed_at: DateTime.parse(row["Date"]),
                                                           receipt_url: row["Attestation"])
-        subscription.wca_id = row["Champ additionnel: ID WCA (si connu)"]
         if subscription.new_record?
+          subscription.assign_attributes(name: row["Nom"].strip,
+                                         firstname: row["Prénom"].strip,
+                                         email: row["Email"]&.strip,
+                                         wca_id: row["Champ additionnel: ID WCA (si connu)"])
           @new_subscriptions << subscription
         else
           @subscriptions << subscription


### PR DESCRIPTION
Changement pour faire un find_by avec en paramètres la date et le numéro de reçu au lieu de l'adhésion en entier quand on importe les adhésions. L'idée est de pouvoir éditer une adhésion après coup en cas d'erreur (nom, prénom, email, id wca (mais surtout pas date et numéro de reçu donc !)). Si la PR est ok, je ferai le formulaire d'édition d'une adhésion dans la foulée